### PR TITLE
saving static only

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,18 +4,6 @@ const port = 3000
 
 app.use(express.static(`public`))
 
-// app.get('/about', (req, res) =>{
-//     res.sendFile(path.join(__dirname, '/public/about/about.html'))
-// })
-
-// app.get('/dev', (req, res) =>{
-//     res.sendFile(path.join(__dirname, '/public/dev/dev.html'))
-// })
-
-// app.get('/', (req, res) =>{
-//     res.sendFile(path.join(__dirname, '/public/home/index.html'))
-// })
-
 app.use((req, res, next) =>{
     if (res.status(404)){
         res.redirect('/home/home.html')


### PR DESCRIPTION
Uses express.static to serve entire static site.
Uses res.redirect to handle 404 requests and sends them to home.html.